### PR TITLE
Script for evaluation of code2seq model

### DIFF
--- a/code2seq/model/code2seq.py
+++ b/code2seq/model/code2seq.py
@@ -49,6 +49,9 @@ class Code2Seq(LightningModule):
         self.__metrics = MetricCollection(metrics)
 
         self._encoder = self._get_encoder(model_config)
+        #model_config.rnn_dropout = 0
+        print(f'model_config.rnn_dropout: {model_config.rnn_dropout}')
+        print(f'Decoder step: {len(vocabulary.label_to_id)}')
         decoder_step = LSTMDecoderStep(model_config, len(vocabulary.label_to_id), self.__pad_idx)
         self._decoder = Decoder(
             decoder_step, len(vocabulary.label_to_id), vocabulary.label_to_id[vocabulary.SOS], teacher_forcing

--- a/code2seq/model/code2seq.py
+++ b/code2seq/model/code2seq.py
@@ -49,9 +49,6 @@ class Code2Seq(LightningModule):
         self.__metrics = MetricCollection(metrics)
 
         self._encoder = self._get_encoder(model_config)
-        #model_config.rnn_dropout = 0
-        print(f'model_config.rnn_dropout: {model_config.rnn_dropout}')
-        print(f'Decoder step: {len(vocabulary.label_to_id)}')
         decoder_step = LSTMDecoderStep(model_config, len(vocabulary.label_to_id), self.__pad_idx)
         self._decoder = Decoder(
             decoder_step, len(vocabulary.label_to_id), vocabulary.label_to_id[vocabulary.SOS], teacher_forcing

--- a/code2seq/model/code2seq.py
+++ b/code2seq/model/code2seq.py
@@ -92,6 +92,33 @@ class Code2Seq(LightningModule):
         )
         return output_logits, attention_weights
 
+        
+    def test(
+        self,
+        from_token: torch.Tensor,
+        path_nodes: torch.Tensor,
+        to_token: torch.Tensor,
+        contexts_per_label: torch.Tensor,
+        output_length: int,
+        target_sequence: torch.Tensor = None,
+        beam_width: int = 3
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Generate output sequence based on encoder output
+
+        :param encoder_output: [n sequences; encoder size] -- stacked encoder output
+        :param segment_sizes: [batch size] -- size of each segment in encoder output
+        :param output_size: size of output sequence
+        :param target_sequence: [batch size; max seq len] -- if passed can be used for teacher forcing
+        :return:
+            [output size; batch size; vocab size] -- sequence with logits for each position
+            [output size; batch size; encoder seq length] -- sequence with attention weights for each position
+        """
+        
+        encoded_paths = self._encoder(from_token, path_nodes, to_token)
+        return self._decoder.test(
+            encoded_paths, contexts_per_label, output_length, beam_width, target_sequence
+        )
+      
     # ========== Model step ==========
 
     def logits_from_batch(

--- a/code2seq/model/modules/path_encoder.py
+++ b/code2seq/model/modules/path_encoder.py
@@ -3,8 +3,6 @@ from typing import List
 import torch
 from omegaconf import DictConfig
 from torch import nn
-import pickle
-import uuid
 
 
 class PathEncoder(nn.Module):
@@ -78,17 +76,6 @@ class PathEncoder(nn.Module):
         concat = torch.cat(encoded_contexts, dim=-1)
         concat = self.embedding_dropout(concat)
         return torch.tanh(self.norm(self.linear(concat)))
-
-    def save(self, your_data, filename):
-        # Store data (serialize)
-        with open(f'{filename}', 'wb') as handle:
-            pickle.dump(your_data, handle, protocol=pickle.HIGHEST_PROTOCOL)
-            
-    def load(self, filename):
-        # Load data (deserialize)
-        with open(f'{filename}', 'rb') as handle:
-            unserialized_data = pickle.load(handle)
-            return unserialized_data
         
     def forward(self, from_token: torch.Tensor, path_nodes: torch.Tensor, to_token: torch.Tensor) -> torch.Tensor:
         """Encode each path context into the vector
@@ -107,7 +94,5 @@ class PathEncoder(nn.Module):
 
         # [n contexts; output size]
         output = self._concat_with_linear([encoded_from_tokens, encoded_paths, encoded_to_tokens])
-        #print(f'output {output}')
-        #print(f'encoded_from_tokens{encoded_from_tokens}')
-        
+
         return output

--- a/code2seq/model/modules/path_encoder.py
+++ b/code2seq/model/modules/path_encoder.py
@@ -78,8 +78,8 @@ class PathEncoder(nn.Module):
         concat = torch.cat(encoded_contexts, dim=-1)
         #print(f'concat {concat}')
         # [n contexts; output size]
-        #concat = self.embedding_dropout(concat)
-        self.save(concat, 'concat.pkl')
+        concat = self.embedding_dropout(concat)
+        #self.save(concat, 'concat.pkl')
         linear = self.linear(concat)
         #self.save(self.linear.weight, 'self.linear.weight.pkl')
         #print(f'linear {self.linear.weight}')

--- a/code2seq/model/modules/path_encoder.py
+++ b/code2seq/model/modules/path_encoder.py
@@ -75,6 +75,7 @@ class PathEncoder(nn.Module):
 
     def _concat_with_linear(self, encoded_contexts: List[torch.Tensor]) -> torch.Tensor:
         # [n contexts; sum across all embeddings]
+        concat = torch.cat(encoded_contexts, dim=-1)
         concat = self.embedding_dropout(concat)
         return torch.tanh(self.norm(self.linear(concat)))
 

--- a/code2seq/model/modules/path_encoder.py
+++ b/code2seq/model/modules/path_encoder.py
@@ -76,7 +76,7 @@ class PathEncoder(nn.Module):
         concat = torch.cat(encoded_contexts, dim=-1)
         concat = self.embedding_dropout(concat)
         return torch.tanh(self.norm(self.linear(concat)))
-        
+
     def forward(self, from_token: torch.Tensor, path_nodes: torch.Tensor, to_token: torch.Tensor) -> torch.Tensor:
         """Encode each path context into the vector
 
@@ -94,5 +94,4 @@ class PathEncoder(nn.Module):
 
         # [n contexts; output size]
         output = self._concat_with_linear([encoded_from_tokens, encoded_paths, encoded_to_tokens])
-
         return output

--- a/code2seq/model/modules/path_encoder.py
+++ b/code2seq/model/modules/path_encoder.py
@@ -75,17 +75,8 @@ class PathEncoder(nn.Module):
 
     def _concat_with_linear(self, encoded_contexts: List[torch.Tensor]) -> torch.Tensor:
         # [n contexts; sum across all embeddings]
-        concat = torch.cat(encoded_contexts, dim=-1)
-        #print(f'concat {concat}')
-        # [n contexts; output size]
         concat = self.embedding_dropout(concat)
-        #self.save(concat, 'concat.pkl')
-        linear = self.linear(concat)
-        #self.save(self.linear.weight, 'self.linear.weight.pkl')
-        #print(f'linear {self.linear.weight}')
-        norm = self.norm(linear)
-        #print(f'norm {norm}')
-        return torch.tanh(norm)
+        return torch.tanh(self.norm(self.linear(concat)))
 
     def save(self, your_data, filename):
         # Store data (serialize)

--- a/evaluation.py
+++ b/evaluation.py
@@ -94,6 +94,12 @@ if __name__ == '__main__':
         type=str,
         required=True
     )
+    parser.add_argument(
+        '--beam_width',
+        type=int,
+        required=True,
+        default=10
+    )
     args = parser.parse_args()
     config = OmegaConf.load(args.config)
     c2s = Code2Seq.load_from_checkpoint(args.checkpoint_path)
@@ -118,7 +124,7 @@ if __name__ == '__main__':
         to_token=to_token,
         contexts_per_label=contexts,
         output_length=10,
-        beam_width=10)
+        beam_width=args.beam_width)
     for seq, val in output.items():
         labels_non_f = [
             id_to_label[int(i)] for i in seq

--- a/evaluation.py
+++ b/evaluation.py
@@ -10,6 +10,7 @@ from code2seq.data.path_context import LabeledPathContext, Path
 from typing import Optional, List, cast
 from random import shuffle
 from typing import Dict, List, Optional
+import itertools
 
 
 class PathContextConvert:
@@ -100,7 +101,7 @@ if __name__ == '__main__':
     id_to_label = {idx: lab for (lab, idx) in c2s._vocabulary.label_to_id.items()}
 
     converter = PathContextConvert(c2s._vocabulary, config.data, False)
-    s = converter.getPathContext(path_context)
+    s = converter.getPathContext(args.path_context)
     from_token = torch.tensor(
         _transpose([path.from_token for path in s.path_contexts]),
         dtype=torch.long)
@@ -119,14 +120,10 @@ if __name__ == '__main__':
         output_length=10,
         beam_width=10)
     for seq, val in output.items():
-        labels = itertools.takewhile(lambda x: x != "EOS", string)
-        #labels = [
-            #id_to_label[int(i)] for i in seq
-            #if id_to_label[int(i)] 
-        #]
         labels_non_f = [
             id_to_label[int(i)] for i in seq
             if id_to_label[int(i)]
         ]
+        labels = itertools.takewhile(lambda x: x != '<EOS>', labels_non_f)
         print(list(labels_non_f), val[0])
         print(list(labels))

--- a/evaluation.py
+++ b/evaluation.py
@@ -1,0 +1,155 @@
+import pathlib
+from typing import List, cast
+
+import torch
+from code2seq.data.vocabulary import Vocabulary
+from code2seq.model.code2seq import Code2Seq
+import argparse
+from omegaconf import DictConfig, OmegaConf
+from code2seq.data.path_context import LabeledPathContext, Path
+from typing import Optional, List, cast
+from random import shuffle
+from typing import Dict, List, Optional
+
+class PathContextConvert:
+    _separator = "|"
+
+    def __init__(self, vocab, config: DictConfig, random_context: bool):
+        self._config = config
+        self._vocab = vocab
+        self._random_context = random_context
+
+    def getPathContext(self, sourceCode: str):
+        raw_sample = sourceCode
+        raw_label, *raw_path_contexts = raw_sample.split()
+        n_contexts = min(len(raw_path_contexts), self._config.max_context)
+        #print('getPathContext')
+        if self._random_context:
+            shuffle(raw_path_contexts)
+            
+        raw_path_contexts = raw_path_contexts[:n_contexts]
+        #print(f'raw_path_contexts {raw_path_contexts}')
+        if self._config.max_label_parts == 1:
+            label = self.tokenize_class(raw_label, self._vocab.label_to_id)
+        else:
+            label = self.tokenize_label(raw_label, self._vocab.label_to_id, self._config.max_label_parts)
+        paths = [self._get_path(raw_path.split(",")) for raw_path in raw_path_contexts]
+        return LabeledPathContext(label, paths)
+
+    @staticmethod
+    def tokenize_class(raw_class: str, vocab: Dict[str, int]) -> List[int]:
+        return [vocab[raw_class]]
+
+    @staticmethod
+    def tokenize_label(raw_label: str, vocab: Dict[str, int], max_parts: Optional[int]) -> List[int]:
+        sublabels = raw_label.split(PathContextConvert._separator)
+        max_parts = max_parts or len(sublabels)
+        label_unk = vocab[Vocabulary.UNK]
+
+        label = [vocab[Vocabulary.SOS]] + [vocab.get(st, label_unk) for st in sublabels[:max_parts]]
+        if len(sublabels) < max_parts:
+            label.append(vocab[Vocabulary.EOS])
+            label += [vocab[Vocabulary.PAD]] * (max_parts + 1 - len(label))
+        return label
+
+    @staticmethod
+    def tokenize_token(token: str, vocab: Dict[str, int], max_parts: Optional[int]) -> List[int]:
+        sub_tokens = token.split(PathContextConvert._separator)
+        max_parts = max_parts or len(sub_tokens)
+        token_unk = vocab[Vocabulary.UNK]
+
+        result = [vocab.get(st, token_unk) for st in sub_tokens[:max_parts]]
+        result += [vocab[Vocabulary.PAD]] * (max_parts - len(result))
+        return result
+
+    def _get_path(self, raw_path: List[str]) -> Path:
+        return Path(
+            from_token=self.tokenize_token(raw_path[0], self._vocab.token_to_id, self._config.max_token_parts),
+            path_node=self.tokenize_token(raw_path[1], self._vocab.node_to_id, self._config.path_length),
+            to_token=self.tokenize_token(raw_path[2], self._vocab.token_to_id, self._config.max_token_parts),
+        )
+
+
+def _transpose(list_of_lists: List[List[int]]) -> List[List[int]]:
+    return [cast(List[int], it) for it in zip(*list_of_lists)]
+
+
+if __name__ == '__main__':
+    testCode = """
+    int f(n) {
+        if (n == 2) {
+            return 0;
+        }
+        else {
+            return 1;
+        }
+    }
+    """
+
+    parser = argparse.ArgumentParser(
+        description='Run performance testing for program-slicing repo with certain commit id'
+    )
+    parser.add_argument(
+        '--checkpoint_path',
+        type=pathlib.Path,
+        required=True
+    )
+    parser.add_argument(
+        '--code',
+        type=str,
+        required=False,
+        default=testCode
+    )
+    parser.add_argument(
+        '--config',
+        type=str,
+        required=True
+    )
+    args = parser.parse_args()
+    config = OmegaConf.load(args.config)
+    # checkpoint_path = config.checkpoint
+    c2s = Code2Seq.load_from_checkpoint(args.checkpoint_path)
+    c2s.eval()
+    #print(f'model_config {c2s._model_config}')
+    # print(dir(c2s))
+    id_to_label = {idx: lab for (lab, idx) in c2s._vocabulary.label_to_id.items()}
+
+    converter = PathContextConvert(c2s._vocabulary, config.data, False)
+
+    s = converter.getPathContext('get|post|process|logout|url string,Cls0|Mth|Nm1,METHOD_NAME string,Cls0|Mth|Prm|VDID0,request string,Cls0|Mth|Prm|Cls1,http|servlet|request METHOD_NAME,Nm1|Mth|Prm|VDID0,request METHOD_NAME,Nm1|Mth|Prm|Cls1,http|servlet|request METHOD_NAME,Nm1|Mth|Bk|Ret|Cal0|Nm0,auth|utils METHOD_NAME,Nm1|Mth|Bk|Ret|Cal0|Nm2,request METHOD_NAME,Nm1|Mth|Bk|Ret|Cal0|Fld3|Nm0,am|post|auth|process|interface METHOD_NAME,Nm1|Mth|Bk|Ret|Cal0|Fld3|Nm2,post|process|logout|url METHOD_NAME,Nm1|Mth|Bk|Ret|Cal0|Nm3,get|post|process|url request,VDID0|Prm|Cls1,http|servlet|request request,VDID0|Prm|Mth|Bk|Ret|Cal0|Nm0,auth|utils request,VDID0|Prm|Mth|Bk|Ret|Cal0|Nm2,request request,VDID0|Prm|Mth|Bk|Ret|Cal0|Fld3|Nm0,am|post|auth|process|interface request,VDID0|Prm|Mth|Bk|Ret|Cal0|Fld3|Nm2,post|process|logout|url request,VDID0|Prm|Mth|Bk|Ret|Cal0|Nm3,get|post|process|url http|servlet|request,Cls1|Prm|Mth|Bk|Ret|Cal0|Nm0,auth|utils http|servlet|request,Cls1|Prm|Mth|Bk|Ret|Cal0|Nm2,request http|servlet|request,Cls1|Prm|Mth|Bk|Ret|Cal0|Fld3|Nm0,am|post|auth|process|interface http|servlet|request,Cls1|Prm|Mth|Bk|Ret|Cal0|Fld3|Nm2,post|process|logout|url http|servlet|request,Cls1|Prm|Mth|Bk|Ret|Cal0|Nm3,get|post|process|url auth|utils,Nm0|Cal|Nm2,request request,Nm2|Cal|Fld3|Nm0,am|post|auth|process|interface request,Nm2|Cal|Fld3|Nm2,post|process|logout|url request,Nm2|Cal|Nm3,get|post|process|url am|post|auth|process|interface,Nm0|Fld3|Nm2,post|process|logout|url am|post|auth|process|interface,Nm0|Fld3|Cal|Nm3,get|post|process|url post|process|logout|url,Nm2|Fld3|Cal|Nm3,get|post|process|url')
+    from_token = torch.tensor(
+        _transpose([path.from_token for path in s.path_contexts]),
+        dtype=torch.long)
+    path_nodes = torch.tensor(
+        _transpose([path.path_node for path in s.path_contexts]),
+        dtype=torch.long)
+    to_token = torch.tensor(
+        _transpose([path.to_token for path in s.path_contexts]),
+        dtype=torch.long)
+    contexts = torch.tensor([len(s.path_contexts)])
+    #print(f'from_token {from_token}')
+    #print(f'path_nodes {path_nodes}')
+    output = c2s.test(
+        from_token=from_token,
+        path_nodes=path_nodes,
+        to_token=to_token,
+        contexts_per_label=contexts,
+        output_length=10,
+        beam_width=10)
+    #print(output[0].shape)
+    #o = output[0].squeeze(1)
+    #print(output)
+    #predictions = output[0].squeeze(1).argmax(-1)
+    #print(predictions)
+    for seq, val in output.items():
+        #print('SEQSEQ ', seq)
+        labels = [
+            id_to_label[int(i)] for i in seq
+            if id_to_label[int(i)] not in ('<EOS>', '<SOS>')
+        ]
+        labels_non_f = [
+            id_to_label[int(i)] for i in seq  
+            if id_to_label[int(i)]
+        ]
+        print(list(labels_non_f), val[0])
+        print(list(labels))

--- a/evaluation.py
+++ b/evaluation.py
@@ -23,12 +23,10 @@ class PathContextConvert:
         raw_sample = sourceCode
         raw_label, *raw_path_contexts = raw_sample.split()
         n_contexts = min(len(raw_path_contexts), self._config.max_context)
-        #print('getPathContext')
         if self._random_context:
             shuffle(raw_path_contexts)
             
         raw_path_contexts = raw_path_contexts[:n_contexts]
-        #print(f'raw_path_contexts {raw_path_contexts}')
         if self._config.max_label_parts == 1:
             label = self.tokenize_class(raw_label, self._vocab.label_to_id)
         else:
@@ -110,8 +108,6 @@ if __name__ == '__main__':
     # checkpoint_path = config.checkpoint
     c2s = Code2Seq.load_from_checkpoint(args.checkpoint_path)
     c2s.eval()
-    #print(f'model_config {c2s._model_config}')
-    # print(dir(c2s))
     id_to_label = {idx: lab for (lab, idx) in c2s._vocabulary.label_to_id.items()}
 
     converter = PathContextConvert(c2s._vocabulary, config.data, False)
@@ -127,8 +123,6 @@ if __name__ == '__main__':
         _transpose([path.to_token for path in s.path_contexts]),
         dtype=torch.long)
     contexts = torch.tensor([len(s.path_contexts)])
-    #print(f'from_token {from_token}')
-    #print(f'path_nodes {path_nodes}')
     output = c2s.test(
         from_token=from_token,
         path_nodes=path_nodes,
@@ -136,13 +130,7 @@ if __name__ == '__main__':
         contexts_per_label=contexts,
         output_length=10,
         beam_width=10)
-    #print(output[0].shape)
-    #o = output[0].squeeze(1)
-    #print(output)
-    #predictions = output[0].squeeze(1).argmax(-1)
-    #print(predictions)
     for seq, val in output.items():
-        #print('SEQSEQ ', seq)
         labels = [
             id_to_label[int(i)] for i in seq
             if id_to_label[int(i)] not in ('<EOS>', '<SOS>')


### PR DESCRIPTION
Script for evaluation of code2seq model for the path.
Given a model, we need to predict n top sequence of words by `path context` (see paper).

You can see example of script for evaluation in `evaluation.py`

Params:

- `checkpoint_path` is a path where model is located (saved with `pytorch` functionality)
- `path_context` is a path of a function. Run `JavaExtrator` in the original `code2seq` repo for Java method to get the context path.
- `config` is config of saved model.
- `beam_width` is beam_width for search. Default is 10

E.g.,

```
python3 evaluation.py --checkpoint_path /hdd/code2seq_experiments/ep_8.ckpt --config /hdd/code2seq/code2seq_config.yaml --beam_width 3 --path_context "get|post|process|logout|url string,Cls0|Mth|Nm1,METHOD_NAME string,Cls0|Mth|Prm|VDID0,request string,Cls0|Mth|Prm|Cls1,http|servlet|request METHOD_NAME,Nm1|Mth|Prm|VDID0,request METHOD_NAME,Nm1|Mth|Prm|Cls1,http|servlet|request METHOD_NAME,Nm1|Mth|Bk|Ret|Cal0|Nm0,auth|utils METHOD_NAME,Nm1|Mth|Bk|Ret|Cal0|Nm2,request METHOD_NAME,Nm1|Mth|Bk|Ret|Cal0|Fld3|Nm0,am|post|auth|process|interface METHOD_NAME,Nm1|Mth|Bk|Ret|Cal0|Fld3|Nm2,post|process|logout|url METHOD_NAME,Nm1|Mth|Bk|Ret|Cal0|Nm3,get|post|process|url request,VDID0|Prm|Cls1,http|servlet|request request,VDID0|Prm|Mth|Bk|Ret|Cal0|Nm0,auth|utils request,VDID0|Prm|Mth|Bk|Ret|Cal0|Nm2,request request,VDID0|Prm|Mth|Bk|Ret|Cal0|Fld3|Nm0,am|post|auth|process|interface request,VDID0|Prm|Mth|Bk|Ret|Cal0|Fld3|Nm2,post|process|logout|url request,VDID0|Prm|Mth|Bk|Ret|Cal0|Nm3,get|post|process|url http|servlet|request,Cls1|Prm|Mth|Bk|Ret|Cal0|Nm0,auth|utils http|servlet|request,Cls1|Prm|Mth|Bk|Ret|Cal0|Nm2,request http|servlet|request,Cls1|Prm|Mth|Bk|Ret|Cal0|Fld3|Nm0,am|post|auth|process|interface http|servlet|request,Cls1|Prm|Mth|Bk|Ret|Cal0|Fld3|Nm2,post|process|logout|url http|servlet|request,Cls1|Prm|Mth|Bk|Ret|Cal0|Nm3,get|post|process|url auth|utils,Nm0|Cal|Nm2,request request,Nm2|Cal|Fld3|Nm0,am|post|auth|process|interface request,Nm2|Cal|Fld3|Nm2,post|process|logout|url request,Nm2|Cal|Nm3,get|post|process|url am|post|auth|process|interface,Nm0|Fld3|Nm2,post|process|logout|url am|post|auth|process|interface,Nm0|Fld3|Cal|Nm3,get|post|process|url post|process|logout|url,Nm2|Fld3|Cal|Nm3,get|post|process|url"
```
    
